### PR TITLE
Fix monitoring SL/TP detection

### DIFF
--- a/modules/analysisHandler.js
+++ b/modules/analysisHandler.js
@@ -26,7 +26,10 @@ const CACHE_DIR = path.join(__dirname, '..', 'analysis_cache');
 const DXY_SYMBOL = 'TVC:DXY';
 const API_KEY_STATUS_PATH = path.join(__dirname, '..', 'config', 'api_key_status.json');
 const GEMINI_API_URL = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent?key=${process.env.GEMINI_API_KEY}`;
-const supportedPairs = (process.env.SUPPORTED_PAIRS || '').split(',').map(p => p.trim().toUpperCase());
+// Ambil daftar pair yang didukung dari env dengan fallback yang sama seperti di index.js
+const supportedPairs = process.env.SUPPORTED_PAIRS
+    ? process.env.SUPPORTED_PAIRS.split(',').map(p => p.trim().toUpperCase())
+    : ['USDJPY', 'USDCHF', 'GBPUSD'];
 
 
 

--- a/modules/brokerHandler.js
+++ b/modules/brokerHandler.js
@@ -163,7 +163,10 @@ async function getClosingDealInfo(positionId) {
           return null;
       }
       
-      const closingDeal = allDeals.find(deal => deal.position_id === positionId && deal.entry === 1);
+        const closingDeal = allDeals.find(deal =>
+            (deal.position_id === positionId || deal.position === positionId) &&
+            (deal.entry === 1 || deal.entry_type === 1)
+        );
 
       if (closingDeal) {
           console.log(`[BROKER HANDLER] SUKSES! Closing deal yang valid ditemukan untuk position ${positionId}:`, closingDeal);

--- a/modules/commandHandler.js
+++ b/modules/commandHandler.js
@@ -189,14 +189,15 @@ async function handleCloseCommand(text, chatId, whatsappSocket) {
     await whatsappSocket.sendMessage(chatId, { text: `⏳ Mencoba menutup/membatalkan order untuk *${pair}*...` });
 
     try {
-        // PERBAIKAN: Mencari file dengan format yang konsisten
-// PERBAIKAN: Mencari file dengan format yang konsisten
-    const pendingOrderPath = path.join(PENDING_DIR, `trade_${pair}.json`);
-    const livePositionPath = path.join(POSITIONS_DIR, `trade_${pair}.json`); // <-- PERBAIKI PATH INI
+        const pendingOrderPath = path.join(PENDING_DIR, `trade_${pair}.json`);
+        const livePositionPath = path.join(POSITIONS_DIR, `trade_${pair}.json`);
 
-    // Cari di kedua folder, tentukan tipe berdasarkan folder mana yang ada filenya
-    const tradeToClose = await readJsonFile(livePositionPath) || await readJsonFile(pendingOrderPath);
-    const tradeType = await readJsonFile(livePositionPath) ? 'live' : 'pending';
+    // Baca kedua file sekali untuk menentukan sumber trade
+    const liveData = await readJsonFile(livePositionPath);
+    const pendingData = await readJsonFile(pendingOrderPath);
+
+    const tradeToClose = liveData || pendingData;
+    const tradeType = liveData ? 'live' : 'pending';
 
     if (!tradeToClose || !tradeToClose.ticket) {
         return whatsappSocket.sendMessage(chatId, { text: `❌ Tidak ditemukan order aktif atau pending untuk *${pair}*.` });

--- a/modules/monitoringHandler.js
+++ b/modules/monitoringHandler.js
@@ -49,15 +49,18 @@ async function checkAllTrades() {
             // Jika tiket pending order ada di daftar posisi aktif, berarti sudah tereksekusi
             if (activeTickets.includes(pendingData.ticket)) {
                 console.log(`[MONITORING] DETEKSI: Pending order #${pendingData.ticket} telah tereksekusi!`);
-                
-                // Pindahkan file dari folder 'pending_orders' ke 'live_positions'
-                // Pindahkan file dari folder 'pending_orders' ke 'live_positions'
-const newPositionFileName = `trade_${pendingData.symbol}.json`; // <-- NAMA FILE DISTANDARISASI
-const newPath = path.join(POSITIONS_DIR, newPositionFileName);
-// Langsung ganti nama file untuk memindahkannya. Ini lebih efisien.
-await fs.rename(filePath, newPath);
 
-broadcast(`✅ *Order Terekseskusi:* Pending order untuk ${pendingData.symbol} (#${pendingData.ticket}) telah menjadi posisi aktif.`);
+                const newPositionFileName = `trade_${pendingData.symbol}.json`;
+                const newPath = path.join(POSITIONS_DIR, newPositionFileName);
+
+                // Cari detail posisi aktif dari broker untuk memperbarui data
+                const activeInfo = activePositions.find(p => p.ticket === pendingData.ticket);
+                const updatedData = activeInfo ? activeInfo : pendingData;
+
+                await fs.writeFile(newPath, JSON.stringify(updatedData, null, 2));
+                await fs.unlink(filePath).catch(() => {});
+
+                broadcast(`✅ *Order Terekseskusi:* Pending order untuk ${pendingData.symbol} (#${pendingData.ticket}) telah menjadi posisi aktif.`);
             }
         }
 


### PR DESCRIPTION
## Summary
- clean up path handling in close command
- update monitoring to save position details when pending orders execute
- broaden closing deal search to improve SL/TP detection

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_686f9684d1008322bafc744c14497147