### PR TITLE
Add dashboard server and web UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,7 @@ MY_WHATSAPP_ID="62xxxxxxxxxxx@s.whatsapp.net"
 SUPPORTED_PAIRS=USDJPY,USDCHF,GBPUSD,EURUSD
 NOTIFICATION_RECIPIENTS=62xxxxxxxxxxx@s.whatsapp.net,62yyyyyyyyyyy@s.whatsapp.net
 ALLOWED_GROUP_IDS=
+DASHBOARD_TOKEN="changeme"
 
 #############################################
 #             FITUR & OPSI BOT

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # BOT-TRADING
+
+Bot trading ini kini dilengkapi server Express dan dashboard web sederhana.
+
+## Menjalankan
+
+1. Salin `.env.example` menjadi `.env` dan isi `DASHBOARD_TOKEN` dengan token rahasia.
+2. Jalankan `npm install` untuk mengunduh dependensi.
+3. Mulai aplikasi dengan:
+   ```bash
+   npm start
+   ```
+   Perintah tersebut akan menjalankan bot WhatsApp sekaligus server web.
+
+Dashboard dapat diakses melalui `http://localhost:3000` dengan menyertakan header:
+
+```
+Authorization: Bearer <DASHBOARD_TOKEN>
+```
+
+## Fitur Dashboard
+
+- **Dashboard utama** – menampilkan status bot.
+- **Orders** – melihat pending order dan posisi live.
+- **Activity Log** – placeholder log aktivitas.
+- **Manual Control** – menjalankan perintah bot secara manual.
+- **Scheduler** – halaman penjadwalan (placeholder).
+- **Prompt Manager** – mengelola file prompt.
+- **Settings** – mengubah konfigurasi `.env` dan berkas di `config/`.
+- **Recipients Management** – kelola daftar penerima notifikasi.
+
+Semua halaman masih sederhana dan dapat dikembangkan sesuai kebutuhan.

--- a/dashboard/activity.html
+++ b/dashboard/activity.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Activity Log</title>
+</head>
+<body>
+<nav>
+  <a href="index.html">Dashboard</a> |
+  <a href="orders.html">Orders</a> |
+  <a href="activity.html">Activity Log</a> |
+  <a href="manual.html">Manual Control</a> |
+  <a href="scheduler.html">Scheduler</a> |
+  <a href="prompts.html">Prompt Manager</a> |
+  <a href="settings.html">Settings</a> |
+  <a href="recipients.html">Recipients</a>
+</nav>
+<h1>Activity Log</h1>
+<div id="content">Log feature placeholder.</div>
+<script src="main.js"></script>
+</body>
+</html>

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Trading Bot Dashboard</title>
+</head>
+<body>
+<nav>
+  <a href="index.html">Dashboard</a> |
+  <a href="orders.html">Orders</a> |
+  <a href="activity.html">Activity Log</a> |
+  <a href="manual.html">Manual Control</a> |
+  <a href="scheduler.html">Scheduler</a> |
+  <a href="prompts.html">Prompt Manager</a> |
+  <a href="settings.html">Settings</a> |
+  <a href="recipients.html">Recipients</a>
+</nav>
+<h1>Dashboard</h1>
+<div id="content">Loading...</div>
+<script src="main.js"></script>
+</body>
+</html>

--- a/dashboard/main.js
+++ b/dashboard/main.js
@@ -1,0 +1,21 @@
+async function api(path, options = {}) {
+  const token = localStorage.getItem('token');
+  options.headers = options.headers || {};
+  if (token) options.headers['Authorization'] = 'Bearer ' + token;
+  const res = await fetch(path, options);
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+async function loadStatus() {
+  try {
+    const data = await api('/status');
+    document.getElementById('content').innerText = data.message || JSON.stringify(data);
+  } catch (e) {
+    document.getElementById('content').innerText = 'Error: ' + e.message;
+  }
+}
+
+if (location.pathname.endsWith('index.html') || location.pathname === '/') {
+  loadStatus();
+}

--- a/dashboard/manual.html
+++ b/dashboard/manual.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Manual Control</title>
+</head>
+<body>
+<nav>
+  <a href="index.html">Dashboard</a> |
+  <a href="orders.html">Orders</a> |
+  <a href="activity.html">Activity Log</a> |
+  <a href="manual.html">Manual Control</a> |
+  <a href="scheduler.html">Scheduler</a> |
+  <a href="prompts.html">Prompt Manager</a> |
+  <a href="settings.html">Settings</a> |
+  <a href="recipients.html">Recipients</a>
+</nav>
+<h1>Manual Control</h1>
+<div id="content">
+  <input id="cmd" placeholder="/status"/>
+  <button onclick="send()">Send</button>
+  <pre id="result"></pre>
+</div>
+<script src="main.js"></script>
+<script>
+async function send(){
+  const command=document.getElementById('cmd').value;
+  try{
+    const data=await api('/command',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({command})});
+    document.getElementById('result').innerText=data.messages.join('\n');
+  }catch(e){document.getElementById('result').innerText='Error: '+e.message;}
+}
+</script>
+</body>
+</html>

--- a/dashboard/orders.html
+++ b/dashboard/orders.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Orders</title>
+</head>
+<body>
+<nav>
+  <a href="index.html">Dashboard</a> |
+  <a href="orders.html">Orders</a> |
+  <a href="activity.html">Activity Log</a> |
+  <a href="manual.html">Manual Control</a> |
+  <a href="scheduler.html">Scheduler</a> |
+  <a href="prompts.html">Prompt Manager</a> |
+  <a href="settings.html">Settings</a> |
+  <a href="recipients.html">Recipients</a>
+</nav>
+<h1>Orders</h1>
+<div id="content">Loading...</div>
+<script src="main.js"></script>
+<script>
+async function loadOrders(){
+  try{const data=await api('/orders');
+    document.getElementById('content').innerText=JSON.stringify(data,null,2);
+  }catch(e){document.getElementById('content').innerText='Error: '+e.message;}
+}
+loadOrders();
+</script>
+</body>
+</html>

--- a/dashboard/prompts.html
+++ b/dashboard/prompts.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Prompt Manager</title>
+</head>
+<body>
+<nav>
+  <a href="index.html">Dashboard</a> |
+  <a href="orders.html">Orders</a> |
+  <a href="activity.html">Activity Log</a> |
+  <a href="manual.html">Manual Control</a> |
+  <a href="scheduler.html">Scheduler</a> |
+  <a href="prompts.html">Prompt Manager</a> |
+  <a href="settings.html">Settings</a> |
+  <a href="recipients.html">Recipients</a>
+</nav>
+<h1>Prompt Manager</h1>
+<div id="content">Prompt editor placeholder.</div>
+<script src="main.js"></script>
+</body>
+</html>

--- a/dashboard/recipients.html
+++ b/dashboard/recipients.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Recipients</title>
+</head>
+<body>
+<nav>
+  <a href="index.html">Dashboard</a> |
+  <a href="orders.html">Orders</a> |
+  <a href="activity.html">Activity Log</a> |
+  <a href="manual.html">Manual Control</a> |
+  <a href="scheduler.html">Scheduler</a> |
+  <a href="prompts.html">Prompt Manager</a> |
+  <a href="settings.html">Settings</a> |
+  <a href="recipients.html">Recipients</a>
+</nav>
+<h1>Recipients Management</h1>
+<div id="content">Recipients placeholder.</div>
+<script src="main.js"></script>
+</body>
+</html>

--- a/dashboard/scheduler.html
+++ b/dashboard/scheduler.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Scheduler</title>
+</head>
+<body>
+<nav>
+  <a href="index.html">Dashboard</a> |
+  <a href="orders.html">Orders</a> |
+  <a href="activity.html">Activity Log</a> |
+  <a href="manual.html">Manual Control</a> |
+  <a href="scheduler.html">Scheduler</a> |
+  <a href="prompts.html">Prompt Manager</a> |
+  <a href="settings.html">Settings</a> |
+  <a href="recipients.html">Recipients</a>
+</nav>
+<h1>Scheduler</h1>
+<div id="content">Scheduler placeholder.</div>
+<script src="main.js"></script>
+</body>
+</html>

--- a/dashboard/settings.html
+++ b/dashboard/settings.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Settings</title>
+</head>
+<body>
+<nav>
+  <a href="index.html">Dashboard</a> |
+  <a href="orders.html">Orders</a> |
+  <a href="activity.html">Activity Log</a> |
+  <a href="manual.html">Manual Control</a> |
+  <a href="scheduler.html">Scheduler</a> |
+  <a href="prompts.html">Prompt Manager</a> |
+  <a href="settings.html">Settings</a> |
+  <a href="recipients.html">Recipients</a>
+</nav>
+<h1>Settings</h1>
+<div id="content">Settings placeholder.</div>
+<script src="main.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Bot analisis trading otomatis menggunakan Node.js dan WhatsApp.",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js",
+    "start": "concurrently \"node index.js\" \"node server.js\"",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [
@@ -21,8 +21,10 @@
     "@hapi/boom": "^10.0.1",
     "@whiskeysockets/baileys": "^6.7.5",
     "axios": "^1.7.2",
+    "chalk": "^4.1.2",
+    "concurrently": "^9.2.0",
     "dotenv": "^16.4.5",
-	"chalk": "^4.1.2",
+    "express": "^5.1.0",
     "google-auth-library": "^9.11.0",
     "google-spreadsheet": "^4.1.2",
     "node-cron": "^3.0.3",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,181 @@
+const express = require('express');
+const fs = require('fs/promises');
+const path = require('path');
+require('dotenv').config();
+
+const commandHandler = require('./modules/commandHandler');
+
+const app = express();
+app.use(express.json());
+app.use(express.static(path.join(__dirname, 'dashboard')));
+
+const AUTH_TOKEN = process.env.DASHBOARD_TOKEN || '';
+const SUPPORTED_PAIRS = process.env.SUPPORTED_PAIRS ? process.env.SUPPORTED_PAIRS.split(',').map(p=>p.trim().toUpperCase()) : [];
+const CONFIG_DIR = path.join(__dirname, 'config');
+const PENDING_DIR = path.join(__dirname, 'pending_orders');
+const LIVE_DIR = path.join(__dirname, 'live_positions');
+const PROMPT_DIR = path.join(__dirname, 'prompts');
+
+let botSettings = { isNewsEnabled: process.env.ENABLE_NEWS_SEARCH === 'true' };
+
+function auth(req, res, next) {
+  if (!AUTH_TOKEN) return res.status(401).json({ error: 'Unauthorized' });
+  const header = req.headers['authorization'] || '';
+  if (header === `Bearer ${AUTH_TOKEN}`) return next();
+  res.status(401).json({ error: 'Unauthorized' });
+}
+
+async function getStatus() {
+  const fake = { last: '', async sendMessage(id, { text }) { this.last = text; } };
+  await commandHandler.handleConsolidatedStatusCommand(
+    SUPPORTED_PAIRS,
+    botSettings,
+    fake,
+    'dashboard'
+  );
+  return fake.last;
+}
+
+async function loadJsonFiles(dir) {
+  try {
+    const files = await fs.readdir(dir);
+    const result = [];
+    for (const f of files) {
+      if (!f.endsWith('.json')) continue;
+      const data = await fs.readFile(path.join(dir, f), 'utf8');
+      result.push({ file: f, data: JSON.parse(data) });
+    }
+    return result;
+  } catch (err) {
+    return [];
+  }
+}
+
+function parseEnv(str) {
+  const obj = {};
+  str.split(/\n/).forEach(line => {
+    const m = line.match(/^([^=]+)=(.*)$/);
+    if (m) obj[m[1]] = m[2];
+  });
+  return obj;
+}
+
+function stringifyEnv(obj) {
+  return Object.entries(obj)
+    .map(([k, v]) => `${k}=${v}`)
+    .join('\n');
+}
+
+app.get('/status', auth, async (req, res) => {
+  const msg = await getStatus();
+  res.json({ message: msg });
+});
+
+app.get('/orders', auth, async (req, res) => {
+  const pending = await loadJsonFiles(PENDING_DIR);
+  const live = await loadJsonFiles(LIVE_DIR);
+  res.json({ pending, live });
+});
+
+async function executeCommand(text) {
+  const fake = { msgs: [], async sendMessage(id, { text }) { this.msgs.push(text); } };
+  const chatId = 'dashboard';
+  const cmd = text.split(' ')[0].toLowerCase();
+  switch (cmd) {
+    case '/status':
+      await commandHandler.handleConsolidatedStatusCommand(SUPPORTED_PAIRS, botSettings, fake, chatId);
+      break;
+    case '/cls':
+      await commandHandler.handleCloseCommand(text, chatId, fake);
+      break;
+    case '/settings':
+    case '/setting':
+      await commandHandler.handleSettingsCommand(text, botSettings, chatId, fake);
+      break;
+    case '/add_recipient':
+      await commandHandler.handleAddRecipient(text, chatId, fake);
+      break;
+    case '/del_recipient':
+      await commandHandler.handleDelRecipient(text, chatId, fake);
+      break;
+    case '/list_recipients':
+      await commandHandler.handleListRecipients(chatId, fake);
+      break;
+    case '/pause':
+      await commandHandler.handlePauseCommand(fake, chatId);
+      break;
+    case '/resume':
+      await commandHandler.handleResumeCommand(fake, chatId);
+      break;
+    case '/profit_today':
+      await commandHandler.handleProfitTodayCommand(fake, chatId);
+      break;
+    default:
+      fake.msgs.push('Command not handled');
+  }
+  return fake.msgs;
+}
+
+app.post('/command', auth, async (req, res) => {
+  const { command } = req.body;
+  if (!command) return res.status(400).json({ error: 'No command' });
+  try {
+    const result = await executeCommand(command);
+    res.json({ messages: result });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/settings', auth, async (req, res) => {
+  const envPath = path.join(__dirname, '.env');
+  let env = {};
+  try {
+    const data = await fs.readFile(envPath, 'utf8');
+    env = parseEnv(data);
+  } catch {}
+  const configs = await loadJsonFiles(CONFIG_DIR);
+  res.json({ env, configs });
+});
+
+app.post('/settings', auth, async (req, res) => {
+  const { env, configs } = req.body;
+  const envPath = path.join(__dirname, '.env');
+  if (env) {
+    await fs.writeFile(envPath, stringifyEnv(env));
+  }
+  if (Array.isArray(configs)) {
+    for (const c of configs) {
+      if (c.file && c.data) {
+        await fs.writeFile(path.join(CONFIG_DIR, c.file), JSON.stringify(c.data, null, 2));
+      }
+    }
+  }
+  res.json({ status: 'ok' });
+});
+
+app.get('/prompts', auth, async (req, res) => {
+  const file = req.query.file;
+  if (file) {
+    try {
+      const data = await fs.readFile(path.join(PROMPT_DIR, file), 'utf8');
+      return res.json({ file, content: data });
+    } catch (err) {
+      return res.status(404).json({ error: 'Not found' });
+    }
+  }
+  const files = await fs.readdir(PROMPT_DIR);
+  res.json({ files });
+});
+
+app.post('/prompts', auth, async (req, res) => {
+  const { file, content } = req.body;
+  if (!file) return res.status(400).json({ error: 'No file' });
+  await fs.writeFile(path.join(PROMPT_DIR, file), content || '');
+  res.json({ status: 'ok' });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Dashboard server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add Express server with REST endpoints and token auth
- serve simple dashboard pages
- run WhatsApp bot and server concurrently
- document how to use the dashboard
- example token field in `.env.example`

## Testing
- `node server.js` *(runs server)*
- `npm start` *(fails to connect to WhatsApp)*

------
https://chatgpt.com/codex/tasks/task_b_686faa31fad88322a760d28e1ebd1377