### PR TITLE
Refactor dashboard navigation to use shared header

### DIFF
--- a/dashboard/activity.html
+++ b/dashboard/activity.html
@@ -5,16 +5,7 @@
   <title>Activity Log</title>
 </head>
 <body>
-<nav>
-  <a href="index.html">Dashboard</a> |
-  <a href="orders.html">Orders</a> |
-  <a href="activity.html">Activity Log</a> |
-  <a href="manual.html">Manual Control</a> |
-  <a href="scheduler.html">Scheduler</a> |
-  <a href="prompts.html">Prompt Manager</a> |
-  <a href="settings.html">Settings</a> |
-  <a href="recipients.html">Recipients</a>
-</nav>
+<div id="header"></div>
 <h1>Activity Log</h1>
 <div id="content">Log feature placeholder.</div>
 <script src="main.js"></script>

--- a/dashboard/header.html
+++ b/dashboard/header.html
@@ -1,0 +1,10 @@
+<nav>
+  <a href="index.html">Dashboard</a> |
+  <a href="orders.html">Orders</a> |
+  <a href="activity.html">Activity Log</a> |
+  <a href="manual.html">Manual Control</a> |
+  <a href="scheduler.html">Scheduler</a> |
+  <a href="prompts.html">Prompt Manager</a> |
+  <a href="settings.html">Settings</a> |
+  <a href="recipients.html">Recipients</a>
+</nav>

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -5,16 +5,7 @@
   <title>Trading Bot Dashboard</title>
 </head>
 <body>
-<nav>
-  <a href="index.html">Dashboard</a> |
-  <a href="orders.html">Orders</a> |
-  <a href="activity.html">Activity Log</a> |
-  <a href="manual.html">Manual Control</a> |
-  <a href="scheduler.html">Scheduler</a> |
-  <a href="prompts.html">Prompt Manager</a> |
-  <a href="settings.html">Settings</a> |
-  <a href="recipients.html">Recipients</a>
-</nav>
+<div id="header"></div>
 <h1>Dashboard</h1>
 <div id="content">Loading...</div>
 <script src="main.js"></script>

--- a/dashboard/main.js
+++ b/dashboard/main.js
@@ -19,3 +19,18 @@ async function loadStatus() {
 if (location.pathname.endsWith('index.html') || location.pathname === '/') {
   loadStatus();
 }
+
+async function insertHeader() {
+  const el = document.getElementById('header');
+  if (!el) return;
+  try {
+    const res = await fetch('header.html');
+    if (res.ok) {
+      el.innerHTML = await res.text();
+    }
+  } catch (e) {
+    console.error('Failed to load header', e);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', insertHeader);

--- a/dashboard/manual.html
+++ b/dashboard/manual.html
@@ -5,16 +5,7 @@
   <title>Manual Control</title>
 </head>
 <body>
-<nav>
-  <a href="index.html">Dashboard</a> |
-  <a href="orders.html">Orders</a> |
-  <a href="activity.html">Activity Log</a> |
-  <a href="manual.html">Manual Control</a> |
-  <a href="scheduler.html">Scheduler</a> |
-  <a href="prompts.html">Prompt Manager</a> |
-  <a href="settings.html">Settings</a> |
-  <a href="recipients.html">Recipients</a>
-</nav>
+<div id="header"></div>
 <h1>Manual Control</h1>
 <div id="content">
   <input id="cmd" placeholder="/status"/>

--- a/dashboard/orders.html
+++ b/dashboard/orders.html
@@ -5,16 +5,7 @@
   <title>Orders</title>
 </head>
 <body>
-<nav>
-  <a href="index.html">Dashboard</a> |
-  <a href="orders.html">Orders</a> |
-  <a href="activity.html">Activity Log</a> |
-  <a href="manual.html">Manual Control</a> |
-  <a href="scheduler.html">Scheduler</a> |
-  <a href="prompts.html">Prompt Manager</a> |
-  <a href="settings.html">Settings</a> |
-  <a href="recipients.html">Recipients</a>
-</nav>
+<div id="header"></div>
 <h1>Orders</h1>
 <div id="content">Loading...</div>
 <script src="main.js"></script>

--- a/dashboard/prompts.html
+++ b/dashboard/prompts.html
@@ -5,16 +5,7 @@
   <title>Prompt Manager</title>
 </head>
 <body>
-<nav>
-  <a href="index.html">Dashboard</a> |
-  <a href="orders.html">Orders</a> |
-  <a href="activity.html">Activity Log</a> |
-  <a href="manual.html">Manual Control</a> |
-  <a href="scheduler.html">Scheduler</a> |
-  <a href="prompts.html">Prompt Manager</a> |
-  <a href="settings.html">Settings</a> |
-  <a href="recipients.html">Recipients</a>
-</nav>
+<div id="header"></div>
 <h1>Prompt Manager</h1>
 <div id="content">Prompt editor placeholder.</div>
 <script src="main.js"></script>

--- a/dashboard/recipients.html
+++ b/dashboard/recipients.html
@@ -5,16 +5,7 @@
   <title>Recipients</title>
 </head>
 <body>
-<nav>
-  <a href="index.html">Dashboard</a> |
-  <a href="orders.html">Orders</a> |
-  <a href="activity.html">Activity Log</a> |
-  <a href="manual.html">Manual Control</a> |
-  <a href="scheduler.html">Scheduler</a> |
-  <a href="prompts.html">Prompt Manager</a> |
-  <a href="settings.html">Settings</a> |
-  <a href="recipients.html">Recipients</a>
-</nav>
+<div id="header"></div>
 <h1>Recipients Management</h1>
 <div id="content">Recipients placeholder.</div>
 <script src="main.js"></script>

--- a/dashboard/scheduler.html
+++ b/dashboard/scheduler.html
@@ -5,16 +5,7 @@
   <title>Scheduler</title>
 </head>
 <body>
-<nav>
-  <a href="index.html">Dashboard</a> |
-  <a href="orders.html">Orders</a> |
-  <a href="activity.html">Activity Log</a> |
-  <a href="manual.html">Manual Control</a> |
-  <a href="scheduler.html">Scheduler</a> |
-  <a href="prompts.html">Prompt Manager</a> |
-  <a href="settings.html">Settings</a> |
-  <a href="recipients.html">Recipients</a>
-</nav>
+<div id="header"></div>
 <h1>Scheduler</h1>
 <div id="content">Scheduler placeholder.</div>
 <script src="main.js"></script>

--- a/dashboard/settings.html
+++ b/dashboard/settings.html
@@ -5,16 +5,7 @@
   <title>Settings</title>
 </head>
 <body>
-<nav>
-  <a href="index.html">Dashboard</a> |
-  <a href="orders.html">Orders</a> |
-  <a href="activity.html">Activity Log</a> |
-  <a href="manual.html">Manual Control</a> |
-  <a href="scheduler.html">Scheduler</a> |
-  <a href="prompts.html">Prompt Manager</a> |
-  <a href="settings.html">Settings</a> |
-  <a href="recipients.html">Recipients</a>
-</nav>
+<div id="header"></div>
 <h1>Settings</h1>
 <div id="content">Settings placeholder.</div>
 <script src="main.js"></script>


### PR DESCRIPTION
## Summary
- add a reusable `header.html` containing the navigation bar
- load the shared header dynamically in `main.js`
- update each dashboard HTML page to include a placeholder div for the header

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_686fb33ace70832298ec6f2d2ac6e937