### PR TITLE
Improve README usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,22 @@
 
 Bot trading ini kini dilengkapi server Express dan dashboard web sederhana.
 
-## Menjalankan
+## Instalasi dan Menjalankan
 
-1. Salin `.env.example` menjadi `.env` dan isi `DASHBOARD_TOKEN` dengan token rahasia.
-2. Jalankan `npm install` untuk mengunduh dependensi.
-3. Mulai aplikasi dengan:
+1. Pastikan Node.js versi 18 atau lebih baru telah terpasang.
+2. Salin `.env.example` menjadi `.env` lalu isi variabel yang dibutuhkan, terutama `DASHBOARD_TOKEN`.
+3. Jalankan `npm install` untuk mengunduh seluruh dependensi.
+4. Mulai aplikasi dengan perintah:
+
    ```bash
    npm start
    ```
-   Perintah tersebut akan menjalankan bot WhatsApp sekaligus server web.
 
-Dashboard dapat diakses melalui `http://localhost:3000` dengan menyertakan header:
+   Perintah di atas menjalankan bot WhatsApp sekaligus server dashboard. Secara
+   default dashboard tersedia di `http://localhost:3000` atau port yang diatur
+   melalui variabel `PORT` pada `.env`.
+
+Seluruh permintaan ke dashboard atau API harus menyertakan header:
 
 ```
 Authorization: Bearer <DASHBOARD_TOKEN>
@@ -30,3 +35,15 @@ Authorization: Bearer <DASHBOARD_TOKEN>
 - **Recipients Management** – kelola daftar penerima notifikasi.
 
 Semua halaman masih sederhana dan dapat dikembangkan sesuai kebutuhan.
+
+## REST API
+
+Setiap endpoint di bawah ini memerlukan header `Authorization: Bearer <DASHBOARD_TOKEN>`:
+
+- `GET /status` – status terkini bot.
+- `GET /orders` – daftar pending order dan posisi aktif.
+- `POST /command` – menjalankan perintah bot, body `{ "command": "<cmd>" }`.
+- `GET /settings` – membaca file `.env` dan konfigurasi di folder `config/`.
+- `POST /settings` – menyimpan pengaturan yang dikirim pada body.
+- `GET /prompts` – menampilkan daftar berkas prompt atau isi berkas jika memakai parameter `file`.
+- `POST /prompts` – menyimpan berkas prompt, body `{ "file": "name.txt", "content": "..." }`.


### PR DESCRIPTION
## Summary
- clarify installation and startup steps
- document REST API endpoints and required auth header
- fix minor formatting and line breaks in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_686fb342c7948322b29043d673978ebf